### PR TITLE
Parsing of mdns packets

### DIFF
--- a/mdns.c
+++ b/mdns.c
@@ -864,7 +864,29 @@ struct mdns_pkt *mdns_parse_pkt(uint8_t *pkt_buf, size_t pkt_len) {
 		off += l;
 	}
 
-	// TODO: parse the authority and additional RR sections
+	// parse authority RRs
+	for (i = 0; i < pkt->num_auth_rr; i++) {
+		size_t l = mdns_parse_rr(pkt_buf, pkt_len, off, &pkt->rr_auth);
+		if (! l) {
+			DEBUG_PRINTF("error parsing authority #%d\n", i);
+			mdns_pkt_destroy(pkt);
+			return NULL;
+		}
+
+		off += l;
+	}
+
+	// parse additional RRs
+	for (i = 0; i < pkt->num_add_rr; i++) {
+		size_t l = mdns_parse_rr(pkt_buf, pkt_len, off, &pkt->rr_add);
+		if (! l) {
+			DEBUG_PRINTF("error parsing additional #%d\n", i);
+			mdns_pkt_destroy(pkt);
+			return NULL;
+		}
+
+		off += l;
+	}
 
 	return pkt;
 }

--- a/mdns.c
+++ b/mdns.c
@@ -601,14 +601,13 @@ uint32_t mdns_read_u32(const uint8_t *ptr) {
 			((ptr[3] & 0xFF) <<  0);
 }
 
-// initialize the packet for reply
 // clears the packet of list structures but not its list items
-void mdns_init_reply(struct mdns_pkt *pkt, uint16_t id) {
+void mdns_init_pkt(struct mdns_pkt *pkt, uint16_t id) {
 	// copy transaction ID
 	pkt->id = id;
 
-	// response flags
-	pkt->flags = MDNS_FLAG_RESP | MDNS_FLAG_AA;
+	// question flags
+	pkt->flags = 0;
 
 	rr_list_destroy(pkt->rr_qn,   0);
 	rr_list_destroy(pkt->rr_ans,  0);
@@ -624,6 +623,14 @@ void mdns_init_reply(struct mdns_pkt *pkt, uint16_t id) {
 	pkt->num_ans_rr = 0;
 	pkt->num_auth_rr = 0;
 	pkt->num_add_rr = 0;
+}
+
+// initialize the packet for reply
+void mdns_init_reply(struct mdns_pkt *pkt, uint16_t id) {
+	mdns_init_pkt(pkt, id);
+
+	// response flags
+	pkt->flags = MDNS_FLAG_RESP | MDNS_FLAG_AA;
 }
 
 // destroys an mdns_pkt struct, including its contents

--- a/mdns.c
+++ b/mdns.c
@@ -1044,16 +1044,13 @@ size_t mdns_encode_pkt(struct mdns_pkt *answer, uint8_t *pkt_buf, size_t pkt_len
 	//uint8_t *e = pkt_buf + pkt_len;
 	size_t off;
 	int i;
-	struct rr_list *rr_set[3];
+	struct rr_list *rr_set[4];
 
 	assert(answer != NULL);
 	assert(pkt_len >= 12);
 
 	if (p == NULL)
 		return -1;
-
-	// this is an Answer - number of qns should be zero
-	assert(answer->num_qn == 0);
 
 	p = mdns_write_u16(p, answer->id);
 	p = mdns_write_u16(p, answer->flags);
@@ -1075,9 +1072,10 @@ size_t mdns_encode_pkt(struct mdns_pkt *answer, uint8_t *pkt_buf, size_t pkt_len
 	comp->pos = 0;
 
 	// skip encoding of qn
-	rr_set[0] =	answer->rr_ans;
-	rr_set[1] = answer->rr_auth;
-	rr_set[2] =	answer->rr_add;
+	rr_set[0] =	answer->rr_qn;
+	rr_set[1] =	answer->rr_ans;
+	rr_set[2] = answer->rr_auth;
+	rr_set[3] =	answer->rr_add;
 
 	// encode answer, authority and additional RRs
 	for (i = 0; i < sizeof(rr_set) / sizeof(rr_set[0]); i++) {

--- a/mdns.c
+++ b/mdns.c
@@ -790,6 +790,18 @@ static size_t mdns_parse_rr(uint8_t *pkt_buf, size_t pkt_len, size_t off,
 			}
 			break;
 
+		case RR_SRV:
+			srv_rec = &rr->data.SRV;
+			srv_rec->priority = mdns_read_u16(p);
+			p += sizeof(uint16_t);
+			srv_rec->weight = mdns_read_u16(p);
+			p += sizeof(uint16_t);
+			srv_rec->port = mdns_read_u16(p);
+			p += sizeof(uint16_t);
+			srv_rec->target = uncompress_nlabel(pkt_buf, pkt_len, p - pkt_buf);
+			p += label_len(pkt_buf, pkt_len, p - pkt_buf);
+			break;
+
 		default:
 			// skip to end of RR data
 			p = e;

--- a/mdns.c
+++ b/mdns.c
@@ -982,10 +982,12 @@ static size_t mdns_encode_rr(uint8_t *pkt_buf, size_t pkt_len, size_t off,
 			break;
 
 		case RR_PTR:
-			label = rr->data.PTR.name ? 
-					rr->data.PTR.name : 
-					rr->data.PTR.entry->name;
-			p += mdns_encode_name(pkt_buf, pkt_len, p - pkt_buf, label, comp);
+			if (rr->data.PTR.name != NULL || rr->data.PTR.entry != NULL) {
+				label = rr->data.PTR.name ? 
+						rr->data.PTR.name : 
+						rr->data.PTR.entry->name;
+				p += mdns_encode_name(pkt_buf, pkt_len, p - pkt_buf, label, comp);
+			}
 			break;
 
 		case RR_TXT:

--- a/mdns.h
+++ b/mdns.h
@@ -169,6 +169,7 @@ struct mdns_pkt {
 struct mdns_pkt *mdns_parse_pkt(uint8_t *pkt_buf, size_t pkt_len);
 
 void mdns_init_reply(struct mdns_pkt *pkt, uint16_t id);
+void mdns_init_pkt(struct mdns_pkt *pkt, uint16_t id);
 size_t mdns_encode_pkt(struct mdns_pkt *answer, uint8_t *pkt_buf, size_t pkt_len);
 
 void mdns_pkt_destroy(struct mdns_pkt *p);


### PR DESCRIPTION
This pull request allows to have a complete parsing of messages and the announcement.
It populates all fields of mdns_pkt on packet reception, and displays each entry in debug mode.

This a first step to activate a function on a specific answer.